### PR TITLE
Add info about importing styles to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ class MyApp extends Component {
 }
 ```
 
+In some cases you might need to additionally import styles separately:
+
+```
+import 'react-calendar/dist/Calendar.css'
+import '@wojtekmaj/react-daterange-picker/dist/DateRangePicker.css'
+```
+
 ### Custom styling
 
 If you don't want to use default React-DateRange-Picker styling to build upon it, you can import React-DateRange-Picker by using `import DateRangePicker from '@wojtekmaj/react-daterange-picker/dist/entry.nostyle';` instead.


### PR DESCRIPTION
Hi, when I used the picker in my project styles were not imported so I had to import them manually. This information might be useful for others so I included it in readme.