### PR TITLE
Add ontouchstart for mobile safari

### DIFF
--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -33,6 +33,7 @@ export default class DateRangePicker extends PureComponent {
   componentDidMount() {
     document.addEventListener('mousedown', this.onOutsideAction);
     document.addEventListener('focusin', this.onOutsideAction);
+    document.addEventListener('touchstart', this.onOutsideAction);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -47,6 +48,7 @@ export default class DateRangePicker extends PureComponent {
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.onOutsideAction);
     document.removeEventListener('focusin', this.onOutsideAction);
+    document.removeEventListener('touchstart', this.onOutsideAction);
   }
 
   onOutsideAction = (event) => {

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -12,6 +12,8 @@ import { callIfDefined } from './shared/utils';
 
 const baseClassName = 'react-daterange-picker';
 
+const outsideActionEvents = ['mousedown', 'focusin', 'touchstart'];
+
 export default class DateRangePicker extends PureComponent {
   static getDerivedStateFromProps(nextProps, prevState) {
     if (nextProps.isOpen !== prevState.isOpenProps) {
@@ -31,9 +33,9 @@ export default class DateRangePicker extends PureComponent {
   }
 
   componentDidMount() {
-    document.addEventListener('mousedown', this.onOutsideAction);
-    document.addEventListener('focusin', this.onOutsideAction);
-    document.addEventListener('touchstart', this.onOutsideAction);
+    outsideActionEvents.forEach(
+      eventName => document.addEventListener(eventName, this.onOutsideAction),
+    );
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -46,9 +48,9 @@ export default class DateRangePicker extends PureComponent {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mousedown', this.onOutsideAction);
-    document.removeEventListener('focusin', this.onOutsideAction);
-    document.removeEventListener('touchstart', this.onOutsideAction);
+    outsideActionEvents.forEach(
+      eventName => document.removeEventListener(eventName, this.onOutsideAction),
+    );
   }
 
   onOutsideAction = (event) => {

--- a/src/__tests__/DateRangePicker.jsx
+++ b/src/__tests__/DateRangePicker.jsx
@@ -211,6 +211,23 @@ describe('DateRangePicker', () => {
     expect(component.state('isOpen')).toBe(false);
   });
 
+  it('closes Calendar component when tapping outside', () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    const component = mount(
+      <DateRangePicker isOpen />,
+      { attachTo: root }
+    );
+
+    const event = document.createEvent('TouchEvent');
+    event.initEvent('touchstart', true, true);
+    document.body.dispatchEvent(event);
+    component.update();
+
+    expect(component.state('isOpen')).toBe(false);
+  });
+
   it('does not close Calendar component when focused inside', () => {
     const component = mount(
       <DateRangePicker isOpen />


### PR DESCRIPTION
# Description

While using this component in mobile safari, the user is unable to tap outside and close the calendar which is a big issue (the user always has to select a range to close the range picker). This PR fixes this and will help make the library more mobile friendly.

## Changes included

Add `ontouchstart` listener for closing the calendar and unit tests for it

## How this was tested
- Unit test
- Manual testing with an iOS emulator with safari in an iPhone 7