### PR TITLE
Upgrade React-Calendar to 3.0.0 

### DIFF
--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -2,9 +2,9 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import makeEventProps from 'make-event-props';
 import mergeClassNames from 'merge-class-names';
+import Calendar from 'react-calendar';
 import Fit from 'react-fit';
 
-import Calendar from 'react-calendar/dist/entry.nostyle';
 import DateInput from 'react-date-picker/dist/DateInput';
 
 import { isMaxDate, isMinDate } from './shared/propTypes';


### PR DESCRIPTION
Requires https://github.com/wojtekmaj/react-date-picker/pull/238 to be merged & released first.